### PR TITLE
refactor(constants): moved constants to dedicated package

### DIFF
--- a/hdl-prj.json
+++ b/hdl-prj.json
@@ -7,6 +7,7 @@
     },
     "files": [
         { "file": "src/alu.vhdl",                "library": "Src" },
+        { "file": "src/constants.vhdl",          "library": "Src" },
         { "file": "src/register_bank.vhdl",      "library": "Src" },
         { "file": "tests/clock.vhdl",            "library": "Tests" },
         { "file": "tests/alu_tb.vhdl",           "library": "Tests" },

--- a/src/alu.vhdl
+++ b/src/alu.vhdl
@@ -22,26 +22,26 @@ use IEEE.Std_Logic_1164.all;
 use IEEE.Numeric_Std.all;
 
 use work.ALUPkg.all;
+use work.Constants;
 
 entity ALU is
-    generic (word_size: positive := 32);
     port (
-        signal A, B: in signed(word_size - 1 downto 0);
+        signal A, B: in signed(Constants.WORD_SIZE - 1 downto 0);
         signal op_code: in op_code_name;
-        signal C: out signed(word_size - 1 downto 0);
+        signal C: out signed(Constants.WORD_SIZE - 1 downto 0);
         signal state: out state_type
     );
 end entity ALU;
 
 
 architecture Rtl of ALU is
-    signal result: signed(word_size downto 0) := (others => '0');
-    constant EMPTY: signed(word_size - 1 downto 0) := (others => '0');
-    signal A_ext, B_ext: signed(word_size downto 0);
+    signal result: signed(Constants.WORD_SIZE downto 0) := (others => '0');
+    constant EMPTY: signed(Constants.WORD_SIZE - 1 downto 0) := (others => '0');
+    signal A_ext, B_ext: signed(Constants.WORD_SIZE downto 0);
     signal B_sign: std_logic;
 begin
     -- Copy output
-    C <= result(word_size - 1 downto 0);
+    C <= result(result'left - 1 downto 0);
     -- Append '0' to inputs
     A_ext <= '0' & A;
     B_ext <= '0' & B;

--- a/src/constants.vhdl
+++ b/src/constants.vhdl
@@ -1,0 +1,4 @@
+package Constants is
+    constant WORD_SIZE: positive := 32;
+    constant REG_ADDR_SIZE: positive := 5;
+end package Constants;

--- a/src/register_bank.vhdl
+++ b/src/register_bank.vhdl
@@ -2,23 +2,21 @@ library IEEE;
 use IEEE.Std_Logic_1164.all;
 use IEEE.Numeric_Std.all;
 
+use work.Constants;
+
 entity RegisterBank is
-    generic (
-        word_size: positive := 32;
-        addr_size: positive := 5
-    );
     port (
-        signal RA, RB, RC: in unsigned(addr_size - 1 downto 0);
-        signal C: in std_logic_vector(word_size - 1 downto 0);
+        signal RA, RB, RC: in unsigned(Constants.REG_ADDR_SIZE - 1 downto 0);
+        signal C: in std_logic_vector(Constants.WORD_SIZE - 1 downto 0);
         signal clk, rst, load: in std_logic;
-        signal A, B: out std_logic_vector(word_size - 1 downto 0)
+        signal A, B: out std_logic_vector(Constants.WORD_SIZE - 1 downto 0)
     );
 end entity RegisterBank;
 
 
 architecture Rtl of RegisterBank is
-    type reg_state is array(natural range 0 to 2**addr_size - 1)
-                   of std_logic_vector(word_size - 1 downto 0);
+    type reg_state is array(natural range 0 to 2**Constants.REG_ADDR_SIZE - 1)
+                   of std_logic_vector(Constants.WORD_SIZE - 1 downto 0);
     signal state: reg_state := (others => (others => '0'));
 begin
     update_state: process(clk, rst)

--- a/vhdl_ls.toml
+++ b/vhdl_ls.toml
@@ -1,6 +1,7 @@
 [libraries]
 Src.files = [
     "src/alu.vhdl",
+    "src/constants.vhdl",
     "src/register_bank.vhdl",
 ]
 Tests.files = [


### PR DESCRIPTION
Moved all constants used currently in the project to a dedicated package, where they can be pulled from