### PR TITLE
fix(makefile): use printf instead of echo to print formated messages

### DIFF
--- a/makefile
+++ b/makefile
@@ -14,10 +14,10 @@ $(WORK):
 	@if [ ! -d $(WORK) ]; then mkdir $(WORK); fi
 
 $(WORK)/%-obj93.cf: $(shell find $* -type f -name "*.vhdl") | $(WORK)
-	@echo "\033[33;1m[Importing $*]\033[0m"
+	@printf "\033[33;1m[Importing $*]\033[0m\n"
 	@rm -f $@
 	@find $* -type f -name '*.vhdl' -exec ghdl -i --work=$* --workdir=$(WORK) {} +
 
 $(WORK)/%.ghw: $(WORK)/src-obj93.cf $(WORK)/tests-obj93.cf | $(WORK)
-	@echo "\033[32;1m[Simulation]\033[0m"
+	@printf "\033[32;1m[Simulation]\033[0m\n"
 	@ghdl -c --work=tests --workdir=$(WORK) -P$(WORK) -r $* --wave='$(WORK)/$*.ghw'


### PR DESCRIPTION
Some non standard POSIX shells require an extra argument (-e) to interpret backslash escape sequences when using `echo` (as it's a built-in command), leading them to not format the message without it. Standard shells, on the other hand, ignore this argument and interpret it as another message to print. `printf` always interprets these escape sequences, which should fix the formatting issues