### PR TITLE
update program counter to use generic components

### DIFF
--- a/docs/Task.md
+++ b/docs/Task.md
@@ -19,7 +19,7 @@ This document provides an overview of the project's organizational structure. Fo
 | ---- | ------------ | ---------------- | ------------------ | ------------ | ----- |
 | [Control Unit](#Control-Unit) | 2024-06-26 | 2024-06-26 | | CLopMan, ALVAROPING1 | In progress |
 | [Registers](#Registers) | 2024-01-30 | 2024-02-14 | CLopMan, ALVAROPING1, Adri-Extremix | CLopMan, ALVAROPING1, 100472182 | Finished |
-| [PC and IR](#PC-and-IR) | 2024-06-07 | 2024-06-13 | CLopMan, ALVAROPING1| CLopMan, ALVAROPING1 | Finished |
+| [PC and IR](#PC-and-IR) | 2024-06-07 | 2024-07-13 | CLopMan | CLopMan, ALVAROPING1 | Finished |
 | [State Register](#State-Register) | 2024-02-12 | 2024-07-01 | CLopMan | CLopMan | Finished |
 | [Memory](#Memory) | | | | | Not started |
 | [Memory Interface](#Memory-Interface) | | | | | Not started |
@@ -47,7 +47,7 @@ This component controls every signal value in the cpu depending on a 80 bits vec
 ### PC and IR
 The register template developed previously will be used for implementing the IR, without requiring additional code. 
 
-PC features a register and a multiplexer that allows choosing the next update value between the previous value incremented by 4 and the bus. 
+PC features a register and a multiplexer that allows choosing the next update value between the previous value incremented by 4 and the bus. For its implementation GenMultiplexer and GenRegister have been used.
 
 ### State Register
 

--- a/src/program_counter.vhdl
+++ b/src/program_counter.vhdl
@@ -1,9 +1,8 @@
-library ieee;
-use ieee.std_logic_1164.all;
-use ieee.numeric_std.all;
+library IEEE;
+use IEEE.Std_logic_1164.all;
+use IEEE.Numeric_std.all;
 
-library Src;
-use work.Constants;
+use Work.Constants;
 
 entity ProgramCounter is 
     port(

--- a/tests/debug_pkg.vhdl
+++ b/tests/debug_pkg.vhdl
@@ -19,7 +19,7 @@ package body Debug is
         variable stri : integer := 1;
     begin
         for i in a'range loop
-            -- std_logic image starts whit '
+            -- std_logic image starts with '
             -- Must extract the second char, which is the value
             b(stri) := std_logic'image(a((i)))(2);
 

--- a/tests/debug_pkg.vhdl
+++ b/tests/debug_pkg.vhdl
@@ -1,0 +1,24 @@
+library IEEE;
+use IEEE.Std_logic_1164.all;
+use IEEE.Numeric_std.all;
+
+package Debug is
+function to_string ( a: std_logic_vector)
+return string;
+
+end package Debug;
+
+package body Debug is
+function to_string ( a: std_logic_vector) return string is
+variable b : string (1 to a'length) := (others => NUL);
+variable stri : integer := 1; 
+begin
+    for i in a'range loop
+        b(stri) := std_logic'image(a((i)))(2);
+    stri := stri+1;
+    end loop;
+return b;
+end function;
+end package body Debug;
+
+

--- a/tests/debug_pkg.vhdl
+++ b/tests/debug_pkg.vhdl
@@ -2,23 +2,31 @@ library IEEE;
 use IEEE.Std_logic_1164.all;
 use IEEE.Numeric_std.all;
 
-package Debug is
-function to_string ( a: std_logic_vector)
-return string;
 
+-- This package add some utilities for testing
+-- to_string: convert vector to string in order
+-- to be printed with report
+
+package Debug is
+    function to_string(a: std_logic_vector)
+    return string;
 end package Debug;
 
 package body Debug is
-function to_string ( a: std_logic_vector) return string is
-variable b : string (1 to a'length) := (others => NUL);
-variable stri : integer := 1; 
-begin
-    for i in a'range loop
-        b(stri) := std_logic'image(a((i)))(2);
-    stri := stri+1;
-    end loop;
-return b;
-end function;
-end package body Debug;
 
+    function to_string(a: std_logic_vector) return string is
+        variable b : string (1 to a'length) := (others => NUL);
+        variable stri : integer := 1;
+    begin
+        for i in a'range loop
+            -- std_logic image starts whit '
+            -- Must extract the second char, which is the value
+            b(stri) := std_logic'image(a((i)))(2);
+
+            stri := stri + 1;
+        end loop;
+        return b;
+    end function;
+
+end package body Debug;
 

--- a/tests/program_counter_tb.vhdl
+++ b/tests/program_counter_tb.vhdl
@@ -10,10 +10,10 @@ end ProgramCounterTB;
 library Src;
 architecture Tests of ProgramCounterTB is
     constant SIZE: integer := 32;
-    signal s_m2, s_c2: std_logic;
+    signal s_m2, s_c2: std_logic := '0';
     signal s_clk: std_logic := '0';
     signal s_rst: std_logic := '0';
-    signal s_from_bus, s_out_data: std_logic_vector(SIZE - 1 downto 0);
+    signal s_from_bus, s_out_data: std_logic_vector(SIZE - 1 downto 0) := (others => '0');
     signal kill_clock: std_logic := '0';
     --signal internal: std_logic_vector(63 downto 0);
 begin

--- a/tests/program_counter_tb.vhdl
+++ b/tests/program_counter_tb.vhdl
@@ -1,6 +1,8 @@
-library ieee;
-use ieee.std_logic_1164.all;
-use ieee.numeric_std.all;
+library IEEE;
+use IEEE.Std_logic_1164.all;
+use IEEE.Numeric_std.all;
+use Work.Debug.all;
+
 
 entity ProgramCounterTB is
 end ProgramCounterTB;
@@ -13,6 +15,7 @@ architecture Tests of ProgramCounterTB is
     signal s_rst: std_logic := '0';
     signal s_from_bus, s_out_data: std_logic_vector(SIZE - 1 downto 0);
     signal kill_clock: std_logic := '0';
+    --signal internal: std_logic_vector(63 downto 0);
 begin
     pc: entity Src.ProgramCounter port map(
         s_m2,
@@ -20,6 +23,7 @@ begin
         s_clk,
         s_rst,
         s_from_bus,
+        -- internal,
         s_out_data
     );
 
@@ -110,6 +114,7 @@ begin
 
             wait for 10 ns;
             -- output
+            --report "debug::: " &  to_string(internal);
             assert s_out_data = tests(i).C
                 report "failed test "
                     & integer'image(i + 1) & ": out value = "


### PR DESCRIPTION
program counter now uses GenMultiplexer and GenRegister. In addition, a debug package with one function to print std_logic_vectos as strings has been implemented