### PR TITLE
refactor(types): create types module with commonly used types

### DIFF
--- a/src/generic_multiplexer.vhdl
+++ b/src/generic_multiplexer.vhdl
@@ -14,7 +14,7 @@ entity Multiplexer is
     port (
         signal sel: in
             std_logic_vector (sel_size - 1 downto 0) := (others => '0');
-        -- Std_logic_vector instead of array of std_logic_vectors 
+        -- Std_logic_vector instead of array of std_logic_vectors
         -- is used due to standard issues
         -- prev 2008 standard does not allow unconstrained vectors
         signal data_in: in

--- a/src/program_counter.vhdl
+++ b/src/program_counter.vhdl
@@ -3,6 +3,7 @@ use IEEE.Std_logic_1164.all;
 use IEEE.Numeric_std.all;
 
 use Work.Constants;
+use Work.Types;
 
 entity ProgramCounter is 
     port(
@@ -15,10 +16,10 @@ entity ProgramCounter is
         rst: in std_logic;
 
         -- data lines 
-        from_bus: in std_logic_vector(Constants.WORD_SIZE - 1 downto 0) := (others => '0'); 
+        from_bus: in Types.word := (others => '0');
         -- output 
         -- internal: out std_logic_vector(63 downto 0); -- TODO: DELETE
-        out_data: out std_logic_vector(Constants.WORD_SIZE - 1 downto 0) := (others => '0')
+        out_data: out Types.word := (others => '0')
     );
 end ProgramCounter;
 
@@ -28,8 +29,8 @@ architecture behaviour of ProgramCounter is
     signal next_addr: std_logic_vector(Constants.WORD_SIZE * 2 - 1 downto 0)
         := (others => '0');
     -- mux -> reg
-    signal reg_in: std_logic_vector(Constants.WORD_SIZE - 1 downto 0) := (others => '0');
-    signal reg_out: std_logic_vector(Constants.WORD_SIZE - 1 downto 0) := (others => '0');
+    signal reg_in: Types.word := (others => '0');
+    signal reg_out: Types.word := (others => '0');
 begin
     next_addr
     <= std_logic_vector(

--- a/src/program_counter.vhdl
+++ b/src/program_counter.vhdl
@@ -5,25 +5,25 @@ use IEEE.Numeric_std.all;
 use Work.Constants;
 use Work.Types;
 
-entity ProgramCounter is 
+entity ProgramCounter is
     port(
         -- control signal
         m2: in std_logic; -- mutex selector
         c2: in std_logic; -- update signal
 
-        -- clk & reset 
+        -- clk & reset
         clk: in std_logic;
         rst: in std_logic;
 
-        -- data lines 
+        -- data lines
         from_bus: in Types.word := (others => '0');
-        -- output 
+        -- output
         -- internal: out std_logic_vector(63 downto 0); -- TODO: DELETE
         out_data: out Types.word := (others => '0')
     );
 end ProgramCounter;
 
-architecture behaviour of ProgramCounter is 
+architecture behaviour of ProgramCounter is
     constant addr_size: positive := Constants.WORD_SIZE / 8;
     -- cable + 4
     signal next_addr: std_logic_vector(Constants.WORD_SIZE * 2 - 1 downto 0)
@@ -32,12 +32,8 @@ architecture behaviour of ProgramCounter is
     signal reg_in: Types.word := (others => '0');
     signal reg_out: Types.word := (others => '0');
 begin
-    next_addr
-    <= std_logic_vector(
-        unsigned(
-           reg_out 
-        )    
-        + addr_size) & from_bus;
+    next_addr <= std_logic_vector(unsigned(reg_out) + addr_size)
+                 & from_bus;
 
     mux: entity work.Multiplexer
         generic map (
@@ -55,5 +51,4 @@ begin
 
     out_data <= reg_out;
     -- internal <= next_addr; -- TODO: DELETE
-        
 end behaviour;

--- a/src/register_bank.vhdl
+++ b/src/register_bank.vhdl
@@ -3,20 +3,21 @@ use IEEE.Std_Logic_1164.all;
 use IEEE.Numeric_Std.all;
 
 use work.Constants;
+use work.Types;
 
 entity RegisterBank is
     port (
         signal RA, RB, RC: in unsigned(Constants.REG_ADDR_SIZE - 1 downto 0);
-        signal C: in std_logic_vector(Constants.WORD_SIZE - 1 downto 0);
+        signal C: in Types.word;
         signal clk, rst, load: in std_logic;
-        signal A, B: out std_logic_vector(Constants.WORD_SIZE - 1 downto 0)
+        signal A, B: out Types.word
     );
 end entity RegisterBank;
 
 
 architecture Rtl of RegisterBank is
     type reg_state is array(natural range 0 to 2**Constants.REG_ADDR_SIZE - 1)
-                   of std_logic_vector(Constants.WORD_SIZE - 1 downto 0);
+                   of Types.word;
     signal state: reg_state := (others => (others => '0'));
 begin
     update_state: process(clk, rst)

--- a/src/state_register.vhdl
+++ b/src/state_register.vhdl
@@ -11,8 +11,7 @@ entity StateRegister is
         signal in_data0, in_data1: in Types.word;
         signal update: in std_logic;  -- C7 on the diagram. Update register value
         signal selector: in std_logic; -- M7 on the diagram. Select data from bus/SeleC
-        signal out_reg: out Types.word;
-        signal out_inter_delete: out Types.word -- this must be deleted
+        signal out_reg: out Types.word
     );
 end StateRegister;
 
@@ -35,5 +34,4 @@ begin
         );
     regis: entity work.Reg
         port map(clk, rst, update, mux_reg, out_reg);
-    out_inter_delete <= mux_reg;
 end behaviour;

--- a/src/state_register.vhdl
+++ b/src/state_register.vhdl
@@ -3,22 +3,23 @@ use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
 use work.Constants;
+use work.Types;
 
 entity StateRegister is
     port(
         signal clk, rst: in std_logic;
-        signal in_data0, in_data1: in std_logic_vector(Constants.WORD_SIZE - 1 downto 0);
+        signal in_data0, in_data1: in Types.word;
         signal update: in std_logic;  -- C7 on the diagram. Update register value
         signal selector: in std_logic; -- M7 on the diagram. Select data from bus/SeleC
-        signal out_reg: out std_logic_vector(Constants.WORD_SIZE - 1 downto 0);
-        signal out_inter_delete: out std_logic_vector(Constants.WORD_SIZE - 1 downto 0) -- this must be deleted
+        signal out_reg: out Types.word;
+        signal out_inter_delete: out Types.word -- this must be deleted
     );
 end StateRegister;
 
 
 architecture behaviour of StateRegister is
     -- interconexion signals
-    signal mux_reg: std_logic_vector(Constants.WORD_SIZE - 1 downto 0);
+    signal mux_reg: Types.word;
     signal mux_data: std_logic_vector(2*Constants.WORD_SIZE - 1 downto 0);
 begin
     mux_data <= in_data1 & in_data0;

--- a/src/types.vhdl
+++ b/src/types.vhdl
@@ -1,0 +1,10 @@
+library IEEE;
+use IEEE.Std_Logic_1164.all;
+
+use Work.Constants;
+
+-- Commonly used types
+package Types is
+    -- `WORD`-size logic vector
+    subtype word is std_logic_vector(Constants.WORD_SIZE - 1 downto 0);
+end package Types;

--- a/tests/program_counter_tb.vhdl
+++ b/tests/program_counter_tb.vhdl
@@ -1,19 +1,23 @@
 library IEEE;
 use IEEE.Std_logic_1164.all;
 use IEEE.Numeric_std.all;
+
+library Src;
+use Src.Constants;
+use Src.Types;
+
 use Work.Debug.all;
 
 
 entity ProgramCounterTB is
 end ProgramCounterTB;
 
-library Src;
 architecture Tests of ProgramCounterTB is
-    constant SIZE: integer := 32;
+    constant SIZE: integer := Constants.WORD_SIZE;
     signal s_m2, s_c2: std_logic := '0';
     signal s_clk: std_logic := '0';
     signal s_rst: std_logic := '0';
-    signal s_from_bus, s_out_data: std_logic_vector(SIZE - 1 downto 0) := (others => '0');
+    signal s_from_bus, s_out_data: Types.word := (others => '0');
     signal kill_clock: std_logic := '0';
     --signal internal: std_logic_vector(63 downto 0);
 begin
@@ -33,9 +37,9 @@ begin
         type test_case is record
             -- inputs
             m2, c2: std_logic;
-            bus_data: std_logic_vector(SIZE - 1 downto 0);
+            bus_data: Types.word;
             -- output
-            C: std_logic_vector(SIZE - 1 downto 0);
+            C: Types.word;
         end record;
 
         type test_arr is array(natural range <>) of test_case;

--- a/tests/register_bank_tb.vhdl
+++ b/tests/register_bank_tb.vhdl
@@ -3,6 +3,7 @@ use IEEE.Std_Logic_1164.all;
 use IEEE.Numeric_Std.all;
 
 library Src;
+use Src.Types;
 
 -- A testbench has no ports
 entity RegisterBankTB is
@@ -11,9 +12,9 @@ end RegisterBankTB;
 
 architecture Rtl of RegisterBankTB is
     signal RA, RB, RC: unsigned(4 downto 0) := (others => '0');
-    signal C: std_logic_vector(31 downto 0) := (others => '0');
+    signal C: Types.word := (others => '0');
     signal clk, rst, load, clk_kill: std_logic := '0';
-    signal A, B: std_logic_vector(31 downto 0) := (others => '0');
+    signal A, B: Types.word := (others => '0');
 begin
     -- Component instantiation
     register_bank: entity Src.RegisterBank port map (
@@ -29,9 +30,9 @@ begin
             -- Inputs
             RA, RB, RC: unsigned(4 downto 0);
             load: std_logic;
-            C: std_logic_vector(31 downto 0);
+            C: Types.word;
             -- Expected output
-            A, B: std_logic_vector(31 downto 0);
+            A, B: Types.word;
         end record;
         -- The patterns to apply
         type tests_array is array (natural range <>) of tests_case;

--- a/tests/register_tb.vhdl
+++ b/tests/register_tb.vhdl
@@ -111,7 +111,7 @@ begin
     begin
         report "start of test" severity note;
         s_rst <= '1';
-        wait for 10 ns; -- wait for the signal to propagate 
+        wait for 10 ns; -- wait for the signal to propagate
         s_rst <= '0';
         for i in TESTS'range loop
             -- Set the inputs

--- a/tests/state_register_tb.vhdl
+++ b/tests/state_register_tb.vhdl
@@ -4,6 +4,7 @@ use ieee.numeric_std.all;
 
 library Src;
 use Src.Constants;
+use Src.Types;
 
 entity StateRegisterTB is
 end StateRegisterTB;
@@ -17,11 +18,10 @@ architecture Tests of StateRegisterTB is
 
 	signal s_update: std_logic;
 	signal s_selector: std_logic;
-    signal s_in_data0, s_in_data1, s_mux_reg:
-        std_logic_vector(SIZE - 1 downto 0);
+    signal s_in_data0, s_in_data1, s_mux_reg: Types.word;
 
     -- output
-    signal s_out_data: std_logic_vector(SIZE - 1 downto 0);
+    signal s_out_data: Types.word;
 
     -- aux for test
     signal clk_kill: std_logic := '0';
@@ -38,11 +38,11 @@ begin
     process
         type test_case is record
             --inputs
-            in0, in1: std_logic_vector(SIZE - 1 downto 0);
+            in0, in1: Types.word;
             S: std_logic;
             U: std_logic;
             -- output
-            C: std_logic_vector(SIZE - 1 downto 0);
+            C: Types.word;
         end record;
 
         type tests_arr is array (natural range <>) of test_case;

--- a/tests/state_register_tb.vhdl
+++ b/tests/state_register_tb.vhdl
@@ -18,7 +18,7 @@ architecture Tests of StateRegisterTB is
 
 	signal s_update: std_logic;
 	signal s_selector: std_logic;
-    signal s_in_data0, s_in_data1, s_mux_reg: Types.word;
+    signal s_in_data0, s_in_data1: Types.word;
 
     -- output
     signal s_out_data: Types.word;
@@ -30,7 +30,7 @@ begin
         clk, s_rst,
         s_in_data0, s_in_data1,
         s_update, s_selector,
-        s_out_data, s_mux_reg
+        s_out_data
     );
 
     clock: entity work.Clock port map (clk_kill, clk);


### PR DESCRIPTION
Created a module for commonly used types throughout the codebase. Currently it only contains a `word` type that represents a logic vector of the processor word size (alias of `std_logic_vector(Constants.WORD_SIZE - 1 downto 0)`), but can be expanded with other types.

While I was at it, I also removed the debug output signal from the state register and formatted the code to remove extraneous whitespaces