### PR TITLE
fix(register_bank): hardwire zero register to a 0 value

### DIFF
--- a/src/register_bank.vhdl
+++ b/src/register_bank.vhdl
@@ -16,22 +16,31 @@ end entity RegisterBank;
 
 
 architecture Rtl of RegisterBank is
-    type reg_state is array(natural range 0 to 2**Constants.REG_ADDR_SIZE - 1)
+    type reg_state is array(natural range 1 to 2**Constants.REG_ADDR_SIZE - 1)
                    of Types.word;
     signal state: reg_state := (others => (others => '0'));
+
+    pure function read(s: reg_state; i: unsigned) return Types.word is
+    begin
+        if i = 0 then
+            return (others => '0');
+        else
+            return s(to_integer(i));
+        end if;
+    end function;
 begin
     update_state: process(clk, rst)
     begin
         if rst = '1' then
             state <= (others => (others => '0'));
         elsif rising_edge(clk) then
-            if load = '1' then
+            if load = '1' and RC /= 0 then
                 state(to_integer(RC)) <= C;
             end if;
         end if;
     end process update_state;
 
     -- Get outputs
-    A <= state(to_integer(RA));
-    B <= state(to_integer(RB));
+    A <= read(state, RA);
+    B <= read(state, RB);
 end architecture Rtl;

--- a/tests/register_bank_tb.vhdl
+++ b/tests/register_bank_tb.vhdl
@@ -39,38 +39,53 @@ begin
         -- The patterns to apply
         type tests_array is array (natural range <>) of tests_case;
         constant TESTS: tests_array := (
-            (
+            ( -- 1: Set C input but don't load value
                 "00000", "00001", "00001", '0',
                 x"0000007f",
                 x"00000000", x"00000000"
             ),
-            (
+            ( -- 2: Set C input and load value
                 "00000", "00001", "00001", '1',
                 x"0000007f",
                 x"00000000", x"0000007f"
             ),
-            (
+            ( -- 3: Modify C input and load value again
                 "00000", "00001", "00001", '1',
                 x"7f000000",
                 x"00000000", x"7f000000"
             ),
-            (
+            ( -- 4: Load different value into a different register and read both
                 "00010", "00001", "00010", '1',
                 x"11111111",
                 x"11111111", x"7f000000"
             ),
-            (
+            ( -- 5: Modify C input but don't load value
                 "00010", "00001", "00010", '0',
                 x"00ff0000",
                 x"11111111", x"7f000000"
             ),
-            (
+            ( -- 6: Read the same register through A and B
                 "00010", "00010", "00010", '0',
                 x"00000000",
                 x"11111111", x"11111111"
             ),
-            (
+            ( -- 7: Read older values stored in different registers
                 "00001", "00000", "00010", '0',
+                x"00000000",
+                x"7f000000", x"00000000"
+            ),
+            ( -- 8: Read zero register
+                "00000", "00001", "00000", '0',
+                x"00000000",
+                x"00000000", x"7f000000"
+            ),
+            ( -- 9: Try to modify the zero register
+                "00000", "00001", "00000", '1',
+                x"33333333",
+                x"00000000", x"7f000000"
+            ),
+            ( -- 10: Read zero register again
+                "00001", "00000", "00000", '0',
                 x"00000000",
                 x"7f000000", x"00000000"
             )


### PR DESCRIPTION
This pr hardwires the zero register from the register bank to a 0 value, preventing it from being modified as the RISC-V spec requires